### PR TITLE
메뉴 페이지 구현 완료 : 탭 이용해서 슬라이딩 애니메이션 추가

### DIFF
--- a/client/src/root.js
+++ b/client/src/root.js
@@ -6,12 +6,14 @@ import './views/styles/pages/common.css';
 import category from './views/pages/category/category';
 import slideAnimation from './services/slideAnimation';
 import replaceBothSideNodes from './services/replaceBothSideNodes';
+import menu from './views/pages/menu';
 
 // List of supported routes. Any url other than these routes will throw a 404 error
 const routes = {
   '/': main,
   '/login': login,
   '/category': category,
+  '/menu': menu,
   // '/p/:id': PostShow,
   // '/register': Register,
 };

--- a/client/src/services/getNodeIndex.js
+++ b/client/src/services/getNodeIndex.js
@@ -1,11 +1,5 @@
 const getNodeIndex = (target) => {
-  for (let i = 0; i < target.parentNode.children.length; i += 1) {
-    if (target.parentNode.children[i] === target) {
-      return i;
-    }
-  }
-
-  return Error;
+  return Array.from(target.parentNode.children).indexOf(target);
 };
 
 export default getNodeIndex;

--- a/client/src/services/getNodeIndex.js
+++ b/client/src/services/getNodeIndex.js
@@ -1,0 +1,11 @@
+const getNodeIndex = (target) => {
+  for (let i = 0; i < target.parentNode.children.length; i += 1) {
+    if (target.parentNode.children[i] === target) {
+      return i;
+    }
+  }
+
+  return Error;
+};
+
+export default getNodeIndex;

--- a/client/src/services/menuSlideAnimation.js
+++ b/client/src/services/menuSlideAnimation.js
@@ -1,0 +1,59 @@
+import chatList from '../views/components/menuTab/chatList';
+import likeList from '../views/components/menuTab/likeList';
+import sellList from '../views/components/menuTab/sellList';
+import getNodeIndex from './getNodeIndex';
+import slideAnimation from './slideAnimation';
+import toggleDisableChildrenButton from './toggleDisableChildrenButton';
+
+const menuSlideAnimation = async (currentNode, { target }) => {
+  const currentIdx = getNodeIndex(currentNode);
+  const targetIdx = getNodeIndex(target);
+
+  const $slideContainer = document.querySelector('.menu .slide');
+  const currentPageNode = $slideContainer.firstElementChild;
+
+  if (currentIdx === targetIdx) return;
+
+  toggleDisableChildrenButton('.menu .tab-bar');
+
+  $slideContainer.addEventListener(
+    'transitionend',
+    () => {
+      console.log('트랜지션끝');
+
+      $slideContainer.style.transition = 'none';
+      $slideContainer.style.transform = `translateX(0px)`;
+      $slideContainer.removeChild(currentPageNode);
+      toggleDisableChildrenButton('.menu .tab-bar');
+    },
+    { once: true }
+  );
+
+  console.log(currentIdx, targetIdx);
+  if (currentIdx < targetIdx) {
+    console.log('오른쪽에 두었다가 왼쪽으로 겹쳐와야함');
+    if (targetIdx === 1) {
+      const chatListItem = await chatList.render();
+      $slideContainer.insertAdjacentHTML('beforeend', chatListItem);
+    } else if (targetIdx === 2) {
+      const likeListItem = await likeList.render();
+      $slideContainer.insertAdjacentHTML('beforeend', likeListItem);
+    }
+    slideAnimation($slideContainer, -435);
+  } else if (currentIdx > targetIdx) {
+    console.log('왼쪽에 두었다가 오른쪽으로 겹쳐와야함');
+    $slideContainer.style.transform = 'translateX(-435px)';
+    if (targetIdx === 0) {
+      const sellListItem = await sellList.render();
+      $slideContainer.insertAdjacentHTML('afterbegin', sellListItem);
+    } else if (targetIdx === 1) {
+      const chatListItem = await chatList.render();
+      $slideContainer.insertAdjacentHTML('afterbegin', chatListItem);
+    }
+    setTimeout(() => {
+      slideAnimation($slideContainer, 0);
+    }, 0);
+  }
+};
+
+export default menuSlideAnimation;

--- a/client/src/services/toggleDisableChildrenButton.js
+++ b/client/src/services/toggleDisableChildrenButton.js
@@ -1,0 +1,9 @@
+const toggleDisableChildrenButton = (classname) => {
+  const $tabBarButtons = document.querySelector(classname).children;
+  Array.from($tabBarButtons).forEach((item) => {
+    const button = item;
+    button.disabled = !button.disabled;
+  });
+};
+
+export default toggleDisableChildrenButton;

--- a/client/src/views/components/button/tab.css
+++ b/client/src/views/components/button/tab.css
@@ -1,16 +1,15 @@
 .button-tab {
   width: 100%;
-  height: 40px;
-  padding: 0px 0px 18px 0px;
+  height: 60px;
+  padding: 18px 0px;
   text-align: center;
   font-size: 16px;
-  background-color: var(--white);
+  background-color: var(--off-white);
   color: var(--grey1);
   cursor: pointer;
 }
 
 .button-tab.active {
   color: var(--primary);
-  height: 38px;
   border-bottom: 2px solid var(--primary);
 }

--- a/client/src/views/components/mainHeader/mainHeader.js
+++ b/client/src/views/components/mainHeader/mainHeader.js
@@ -35,7 +35,9 @@ const mainHeader = {
                   </div>
                   <div class="right-icons">
                     ${userIcon}
-                    ${menuIcon}
+                    <a href="#/menu">
+                      ${menuIcon}
+                    </a>
                   </div>
                 </header>
             `;

--- a/client/src/views/components/menuTab/chatList/chatList.js
+++ b/client/src/views/components/menuTab/chatList/chatList.js
@@ -1,0 +1,30 @@
+import data from '../../../../mockup/chatList.json';
+import chatListItem from '../../chatListItem/chatListItem';
+
+const chatList = {
+  render: async () => {
+    let chatListComponent = ``;
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const item of data) {
+      const { username, message, timestamp, count, img } = item;
+      // eslint-disable-next-line no-await-in-loop
+      chatListComponent += await chatListItem.render(
+        username,
+        message,
+        timestamp,
+        count,
+        img
+      );
+    }
+
+    const view = `<div class="page">
+                    ${chatListComponent}     
+                  </div>`;
+
+    return view;
+  },
+  afterRender: async () => {},
+};
+
+export default chatList;

--- a/client/src/views/components/menuTab/chatList/index.js
+++ b/client/src/views/components/menuTab/chatList/index.js
@@ -1,0 +1,3 @@
+import chatList from './chatList';
+
+export default chatList;

--- a/client/src/views/components/menuTab/likeList/index.js
+++ b/client/src/views/components/menuTab/likeList/index.js
@@ -1,0 +1,3 @@
+import likeList from './likeList';
+
+export default likeList;

--- a/client/src/views/components/menuTab/likeList/likeList.js
+++ b/client/src/views/components/menuTab/likeList/likeList.js
@@ -1,0 +1,35 @@
+import data from '../../../../mockup/likeList.json';
+import productListItem from '../../productListItem/productListItem';
+
+const likeList = {
+  render: async () => {
+    let likeListComponent = ``;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const item of data) {
+      const { img, title, town, locTime, price, isLike, chatCount, likeCount } =
+        item;
+      // eslint-disable-next-line no-await-in-loop
+      likeListComponent += await productListItem.render(
+        false,
+        img,
+        title,
+        town,
+        locTime,
+        price,
+        isLike,
+        chatCount,
+        likeCount
+      );
+    }
+    const view = `<div class="page">
+                    <div>
+                      ${likeListComponent}
+                    </div>
+                  </div>`;
+
+    return view;
+  },
+  afterRender: async () => {},
+};
+
+export default likeList;

--- a/client/src/views/components/menuTab/sellList/index.js
+++ b/client/src/views/components/menuTab/sellList/index.js
@@ -1,0 +1,3 @@
+import sellList from './sellList';
+
+export default sellList;

--- a/client/src/views/components/menuTab/sellList/sellList.js
+++ b/client/src/views/components/menuTab/sellList/sellList.js
@@ -1,0 +1,37 @@
+import data from '../../../../mockup/sellList.json';
+import productListItem from '../../productListItem/productListItem';
+
+const sellList = {
+  render: async () => {
+    let sellListComponent = ``;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const item of data) {
+      const { img, title, town, locTime, price, isLike, chatCount, likeCount } =
+        item;
+      // eslint-disable-next-line no-await-in-loop
+      sellListComponent += await productListItem.render(
+        true,
+        img,
+        title,
+        town,
+        locTime,
+        price,
+        isLike,
+        chatCount,
+        likeCount
+      );
+    }
+
+    const view = `<div class="page">
+                    <div>
+                      ${sellListComponent}
+                    </div>
+                  </div>
+    `;
+
+    return view;
+  },
+  afterRender: async () => {},
+};
+
+export default sellList;

--- a/client/src/views/components/tabBar/tabBar.js
+++ b/client/src/views/components/tabBar/tabBar.js
@@ -15,7 +15,7 @@ const tabBar = {
 
     return view;
   },
-  after_render: async () => {
+  afterRender: async () => {
     const $tabBar = document.querySelector('.tab-bar');
     $tabBar.addEventListener('click', (e) =>
       changeActiveComponent('.tab-bar', e)

--- a/client/src/views/components/tabBar/tabBar.js
+++ b/client/src/views/components/tabBar/tabBar.js
@@ -1,4 +1,3 @@
-import changeActiveComponent from '../../../services/changeActiveComponent';
 import { tab } from '../button';
 import './tabBar.css';
 
@@ -15,12 +14,7 @@ const tabBar = {
 
     return view;
   },
-  afterRender: async () => {
-    const $tabBar = document.querySelector('.tab-bar');
-    $tabBar.addEventListener('click', (e) =>
-      changeActiveComponent('.tab-bar', e)
-    );
-  },
+  afterRender: async () => {},
 };
 
 export default tabBar;

--- a/client/src/views/pages/menu/index.js
+++ b/client/src/views/pages/menu/index.js
@@ -1,0 +1,3 @@
+import menu from './menu';
+
+export default menu;

--- a/client/src/views/pages/menu/menu.css
+++ b/client/src/views/pages/menu/menu.css
@@ -1,0 +1,16 @@
+.menu {
+  overflow: hidden;
+}
+
+.menu .menu-header {
+  border-bottom: none;
+}
+
+.menu .slide {
+  min-width: 435px;
+  display: flex;
+}
+
+.menu .page {
+  min-width: 435px;
+}

--- a/client/src/views/pages/menu/menu.js
+++ b/client/src/views/pages/menu/menu.js
@@ -1,0 +1,45 @@
+import changeActiveComponent from '../../../services/changeActiveComponent';
+import menuSlideAnimation from '../../../services/menuSlideAnimation';
+import icon from '../../components/icon';
+import menuHeader from '../../components/menuHeader';
+import sellList from '../../components/menuTab/sellList';
+import tabBar from '../../components/tabBar/tabBar';
+import './menu.css';
+
+const menu = {
+  render: async () => {
+    const backIcon = await icon.render(
+      'src/images/chevron-left.svg',
+      '뒤로 가기'
+    );
+    const menuHeaderItem = await menuHeader.render(
+      '#/',
+      backIcon,
+      null,
+      '메뉴',
+      'off-white'
+    );
+
+    const tabBarItem = await tabBar.render(['판매목록', '채팅', '관심목록'], 0);
+    const sellListPage = await sellList.render();
+    const view = `<div class="page menu">
+                    ${menuHeaderItem}
+                    ${tabBarItem}
+                    <div class="slide">
+                      ${sellListPage}
+                    </div>
+                  </div>`;
+
+    return view;
+  },
+  afterRender: async () => {
+    const $tabBar = document.querySelector('.tab-bar');
+    $tabBar.addEventListener('click', (e) => {
+      const currentActiveNode = document.querySelector(`.tab-bar .active`);
+      changeActiveComponent('.tab-bar', e);
+      menuSlideAnimation(currentActiveNode, e);
+    });
+  },
+};
+
+export default menu;


### PR DESCRIPTION
closes #8 
closes #19 
closes #27 
closes #28 

![Jul-18-2021 15-47-19](https://user-images.githubusercontent.com/50328132/126058368-46bb706c-587e-448e-a3bc-00f038389099.gif)

구현은 했는데 이후에 json으로 데이터를 받아올때 성능이 어떻게 나올지 궁금하기도 하네요. 이 후 테스트를 위해 console.log는 잠시 놔두도록 해도될까요..?

구현 방식은 페이지 슬라이딩 방식과 비슷합니다

첫번째 탭에서 세번째 탭으로 한번에 갈 때 중간에 두번째 탭을 보여주는게 맞나 고민했는데 안보여주는게 맞다는 판단하에 바로 세번째 탭을 뒤에 붙이고 슬라이딩을 하는 형식으로 구현하였습니다.

또한, 슬라이드 하던 중에 빠르게 다른 탭 버튼을 누르려고 하는 경우가 있는 걸 방지하기 위해 버튼을 disabled하는 토글 함수를 만들었습니다. 트랜지션이 완료된 후에야 버튼이 눌릴 수 있게끔 구현하였습니다.

항상 슬라이딩 애니메이션은 구현이 상당히 복잡한 것 같습니다.. 뭔가 함수도 잘게 쪼개고 싶은데 쉽지가 않네요..ㅠㅠ 계속 고민해야할 사항인 것은 분명한 듯 합니다. 일단 렌더링이 잘되는것은 확인했으니 기본 구현이라 생각하여 pr올립니다. 확인후 코멘트 부탁드립니다! 👍 

아 ! 그리고 giphy capture인가 이거 상당히 좋네요 ㅎㅎ 앞으로 애용해서 pr올릴때 인터렉션 보여드릴때 상당히 좋은 역할을 할 것 같습니다~!