### PR TITLE
추가 : inputPopup 컴포넌트

### DIFF
--- a/client/src/services/changeConfirmButton.js
+++ b/client/src/services/changeConfirmButton.js
@@ -1,0 +1,10 @@
+const changeConfirmButton = (className, { target }) => {
+  if (target.className !== 'medium-input') return;
+  const confirmButton = target
+    .closest(className)
+    .querySelector('.confirm-button');
+  if (/동$/.test(target.value)) confirmButton.classList.add('active');
+  else confirmButton.classList.remove('active');
+};
+
+export default changeConfirmButton;

--- a/client/src/views/components/modal/index.js
+++ b/client/src/views/components/modal/index.js
@@ -1,4 +1,5 @@
 import dropdown from './dropdown';
 import alert from './alert';
+import inputPopup from './inputPopup';
 
-export { dropdown, alert };
+export { dropdown, alert, inputPopup };

--- a/client/src/views/components/modal/inputPopup.css
+++ b/client/src/views/components/modal/inputPopup.css
@@ -1,0 +1,39 @@
+.input-popup {
+  width: 320px;
+  height: 146px;
+  border-radius: 10px;
+  background-color: var(--off-white);
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 2px 4px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 20px;
+}
+
+.popup-message {
+  font-size: 16px;
+  color: var(--title-active);
+  margin-bottom: 10px;
+}
+
+.popup-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.cancel-button,
+.confirm-button {
+  font-size: 16px;
+  font-weight: bold;
+  background-color: inherit;
+}
+
+.popup-buttons > .confirm-button {
+  color: var(--grey1);
+}
+
+.popup-buttons > .confirm-button.active {
+  color: var(--primary);
+}

--- a/client/src/views/components/modal/inputPopup.js
+++ b/client/src/views/components/modal/inputPopup.js
@@ -1,0 +1,37 @@
+import './inputPopup.css';
+import textInput from '../textInput';
+import changeConfirmButton from '../../../services/changeConfirmButton';
+
+const inputPopup = {
+  render: async () => {
+    const popupMessage = '현재 위치를 입력하세요.';
+    const cancelMessage = '취소';
+    const confirmMessage = '확인';
+    const inputTown = await textInput.render(
+      'medium-input',
+      '시·구 제외, 동만 입력'
+    );
+    const view = `
+        <div class="input-popup">
+          <p class="popup-message">
+            ${popupMessage}
+          </p>
+          ${inputTown}
+          <div class="popup-buttons">
+            <Button class="cancel-button">
+              ${cancelMessage}
+            </Button>
+            <Button class="confirm-button">
+              ${confirmMessage}
+            </Button>
+          </div>
+        </div>
+    `;
+
+    return view;
+  },
+
+  afterRender: async () => {
+};
+
+export default inputPopup;

--- a/client/src/views/components/modal/inputPopup.js
+++ b/client/src/views/components/modal/inputPopup.js
@@ -32,6 +32,10 @@ const inputPopup = {
   },
 
   afterRender: async () => {
+    const className = '.input-popup';
+    const $popup = document.querySelector(className);
+    $popup.addEventListener('input', (e) => changeConfirmButton(className, e));
+  },
 };
 
 export default inputPopup;


### PR DESCRIPTION
closes #74 

confirm-button, cancel-button을 alert과 공유하여 따로 뺄까 생각하였었지만,

적합한 폴더 구조가 떠오르지 않았고, 겹치는 곳이 딱 이 컴포넌트 포함 두 곳이라 그대로 사용하였습니다.

추가적으로 어느 정도 임의로 ~~동이기만 하면 확인 버튼이 활성화하도록 했습니다

이유는 주소를 검색하는 기능이 없어 이 이상 front단에서 거를만한 방법이 떠오르지 않았기 때문입니다.


![image](https://user-images.githubusercontent.com/82671736/126076491-d7f59470-c4ab-46b3-8e2f-b8accc6617f8.png)
![image](https://user-images.githubusercontent.com/82671736/126076499-7066e03a-7aa5-43b1-9899-61cf3c8033d2.png)


